### PR TITLE
Dvernier release name too short 740

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,14 +5,14 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Deployment Guide](#deployment-guide)
-    - [Environment variable](#environment-variable)
-    - [RBAC](#rbac)
-        - [Deployment](#deployment)
-        - [General process](#general-process)
-        - [HelmChartSubscriptions](#helmchartsubscriptions)
-        - [Helm-charts filtering](#helm-charts-filtering)
-        - [Authentication](#authentication)
-        - [Helm-repo client configuration](#helm-repo-client-configuration)
+  - [Environment variable](#environment-variable)
+  - [RBAC](#rbac)
+    - [Deployment](#deployment)
+    - [General process](#general-process)
+    - [HelmChartSubscriptions](#helmchartsubscriptions)
+    - [Helm-charts filtering](#helm-charts-filtering)
+    - [Authentication](#authentication)
+    - [Helm-repo client configuration](#helm-repo-client-configuration)
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Environment variable
@@ -71,8 +71,9 @@ spec:
     name: mycluster-config
   name: ibm-myapp-api
   packageFilter:
-    keywords:
-    - ICP
+    labelSelector:
+      matchLabels:
+        "ICP": "true"
     annotations:
       tillerVersion: 2.4.0
     version: '>0.2.2'
@@ -112,7 +113,7 @@ Filtering is done on:
 - the version of the helm-chart (semver expression),
 - the tiller version of the helm-chart (Should may be removed as the operator has its own tiller)
 - the digest must match
-- the keywords, if the helm-chart has a least 1 listed keywords then it eligible for deployment.
+- the labelSelector allows to check if the helm-charts has the required keywords.
 
 ### Authentication
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,14 +5,14 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Deployment Guide](#deployment-guide)
-  - [Environment variable](#environment-variable)
-  - [RBAC](#rbac)
-    - [Deployment](#deployment)
-    - [General process](#general-process)
-    - [HelmChartSubscriptions](#helmchartsubscriptions)
-    - [Helm-charts filtering](#helm-charts-filtering)
-    - [Authentication](#authentication)
-    - [Helm-repo client configuration](#helm-repo-client-configuration)
+    - [Environment variable](#environment-variable)
+    - [RBAC](#rbac)
+        - [Deployment](#deployment)
+        - [General process](#general-process)
+        - [HelmChartSubscriptions](#helmchartsubscriptions)
+        - [Helm-charts filtering](#helm-charts-filtering)
+        - [Authentication](#authentication)
+        - [Helm-repo client configuration](#helm-repo-client-configuration)
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Environment variable

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -39,7 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-
 	appv1alpha1 "github.com/IBM/multicloud-operators-subscription-release/pkg/apis/app/v1alpha1"
 	"github.com/IBM/multicloud-operators-subscription-release/pkg/helmreleasemgr"
 	"github.com/IBM/multicloud-operators-subscription-release/pkg/utils"
@@ -242,7 +241,7 @@ func (r *ReconcileHelmRelease) SetStatus(s *appv1alpha1.HelmRelease, issue error
 		retryInterval = time.Duration(math.Max(float64(time.Second.Nanoseconds()*2), float64(metav1.Now().Sub(lastUpdate).Round(time.Second).Nanoseconds())))
 	}
 
-	requeueAfter := time.Duration(math.Min(float64(retryInterval.Nanoseconds()*2), float64(time.Hour.Nanoseconds()*6)))
+	requeueAfter := time.Duration(math.Min(float64(retryInterval.Nanoseconds()*2), float64(time.Minute.Nanoseconds()*2)))
 	klog.V(5).Info("requeueAfter: ", requeueAfter)
 
 	return reconcile.Result{

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
 	appv1alpha1 "github.com/IBM/multicloud-operators-subscription-release/pkg/apis/app/v1alpha1"
 	"github.com/IBM/multicloud-operators-subscription-release/pkg/helmreleasemgr"
 	"github.com/IBM/multicloud-operators-subscription-release/pkg/utils"

--- a/pkg/helmreleasemgr/helmreleasemgr.go
+++ b/pkg/helmreleasemgr/helmreleasemgr.go
@@ -37,7 +37,12 @@ func NewManager(cfg *rest.Config, configMap *corev1.ConfigMap, secret *corev1.Se
 	o := &unstructured.Unstructured{}
 	o.SetGroupVersionKind(s.GroupVersionKind())
 	o.SetNamespace(s.GetNamespace())
-	releaseName := s.Spec.ReleaseName[0:4]
+
+	releaseName := s.Spec.ReleaseName
+	if len(releaseName) > 4 {
+		releaseName = releaseName[:4]
+	}
+
 	o.SetName(releaseName)
 	klog.V(2).Info("ReleaseName :", o.GetName())
 	o.SetUID(s.GetUID())

--- a/pkg/helmreleasemgr/helmreleasemgr_test.go
+++ b/pkg/helmreleasemgr/helmreleasemgr_test.go
@@ -66,3 +66,38 @@ func TestNewManager(t *testing.T) {
 	_, err = NewManager(mgr.GetConfig(), nil, nil, instance)
 	assert.NoError(t, err)
 }
+
+func TestNewManagerShortReleaseName(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{})
+	assert.NoError(t, err)
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	instance := &appv1alpha1.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmReleaseName,
+			Namespace: helmReleaseNS,
+		},
+		Spec: appv1alpha1.HelmReleaseSpec{
+			Source: &appv1alpha1.Source{
+				SourceType: appv1alpha1.GitHubSourceType,
+				GitHub: &appv1alpha1.GitHub{
+					Urls:      []string{"https://github.com/IBM/multicloud-operators-subscription-release.git"},
+					ChartPath: "test/github/subscription-release-test-1",
+				},
+			},
+			ReleaseName: "sub",
+			ChartName:   "subscription-release-test-1",
+		},
+	}
+
+	_, err = NewManager(mgr.GetConfig(), nil, nil, instance)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- https://github.ibm.com/IBMPrivateCloud/CP4MCM/issues/740 (Panic if releaseName less than 4 chars)
- Reduce the max retry period from 6h to 2 min for helmrelease
- Update doc for keywords vs labelSelector
