### PR TITLE
add team members to owner list and several other updates/fixes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,10 @@
 approvers:
 - kuanf
-- itdove
 - jnpacker
+- itdove
+reviewers:
+- xiangjingli
+- rokej
+- ianzhang366
+- sahare
+- rwellon

--- a/pkg/controller/helmrelease/helmrelease_controller_suite_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_suite_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/IBM/multicloud-operators-subscription-release/pkg/apis"
 )
@@ -59,19 +58,6 @@ func TestMain(m *testing.M) {
 	}
 
 	os.Exit(code)
-}
-
-// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
-// writes the request to requests after Reconcile is finished.
-func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
-	requests := make(chan reconcile.Request)
-	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
-		result, err := inner.Reconcile(req)
-		requests <- req
-		return result, err
-	})
-
-	return fn, requests
 }
 
 // StartTestManager adds recFn

--- a/pkg/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_test.go
@@ -24,34 +24,43 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appv1alpha1 "github.com/IBM/multicloud-operators-subscription-release/pkg/apis/app/v1alpha1"
-	"github.com/IBM/multicloud-operators-subscription-release/pkg/utils"
 )
 
 var (
-	helmReleaseNS = "default"
+	helmReleaseNS = "kube-system"
 )
 
-func TestGithubSuccess(t *testing.T) {
+func TestReconcile(t *testing.T) {
+	defer klog.Flush()
+
 	g := gomega.NewGomegaWithT(t)
 
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 	// channel when it is finished.
+
+	t.Log("Create manager")
+
 	mgr, err := manager.New(cfg, manager.Options{
 		MetricsBindAddress: "0",
 		LeaderElection:     false,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
 
 	c := mgr.GetClient()
+
+	rec := &ReconcileHelmRelease{
+		mgr,
+	}
+
+	t.Log("Setup test reconcile")
+	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 
@@ -63,6 +72,8 @@ func TestGithubSuccess(t *testing.T) {
 	//
 	//Github succeed
 	//
+	t.Log("Github succeed test")
+
 	helmReleaseName := "example-github-succeed"
 	helmReleaseKey := types.NamespacedName{
 		Name:      helmReleaseName,
@@ -93,65 +104,26 @@ func TestGithubSuccess(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	instanceResp := &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
+	t.Logf("Reason: %s", instanceResp.Status.Reason)
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseSuccess))
 
-	secret := &corev1.Secret{}
-	err = c.Get(context.TODO(), types.NamespacedName{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}, secret)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	owners := secret.GetOwnerReferences()
-	g.Expect((len(owners) == 1)).Should(gomega.BeTrue())
-	g.Expect(owners[0].Name).Should(gomega.Equal(instanceResp.Name))
-	g.Expect(owners[0].UID).Should(gomega.Equal(instanceResp.UID))
-
-	deploy := &appv1.DeploymentList{}
-	c.List(context.TODO(), deploy)
-	g.Expect(len(deploy.Items) == 1).To(gomega.BeTrue())
-
-	err = c.Delete(context.TODO(), instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	defer time.Sleep(2 * time.Second)
-}
-
-func TestGithubFailed(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
-	// channel when it is finished.
-
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
-	c := mgr.GetClient()
-
+	//
 	//Github failed
-	helmReleaseName := "example-github-failed"
-	helmReleaseKey := types.NamespacedName{
+	//
+	t.Log("Github failed test")
+
+	helmReleaseName = "example-github-failed"
+	helmReleaseKey = types.NamespacedName{
 		Name:      helmReleaseName,
 		Namespace: helmReleaseNS,
 	}
-	instance := &appv1alpha1.HelmRelease{
+	instance = &appv1alpha1.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HelmRelease",
 			APIVersion: "app.ibm.com/v1alpha1",
@@ -176,49 +148,25 @@ func TestGithubFailed(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	time.Sleep(4 * time.Second)
+	time.Sleep(2 * time.Second)
 
-	instanceResp := &appv1alpha1.HelmRelease{}
+	instanceResp = &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
 
-	err = c.Delete(context.TODO(), instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	defer time.Sleep(2 * time.Second)
-}
-
-func TestHelmRepoSuccess(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
-	// channel when it is finished.
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
-
-	c := mgr.GetClient()
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
 	//
 	//helmRepo succeeds
 	//
-	helmReleaseName := "example-helmrepo-succeed"
-	helmReleaseKey := types.NamespacedName{
+	t.Log("helmrepo succeed test")
+
+	helmReleaseName = "example-helmrepo-succeed"
+	helmReleaseKey = types.NamespacedName{
 		Name:      helmReleaseName,
 		Namespace: helmReleaseNS,
 	}
-	instance := &appv1alpha1.HelmRelease{
+	instance = &appv1alpha1.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HelmRelease",
 			APIVersion: "app.ibm.com/v1alpha1",
@@ -238,12 +186,13 @@ func TestHelmRepoSuccess(t *testing.T) {
 			ChartName:   "subscription-release-test-1",
 		},
 	}
+
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
-	instanceResp := &appv1alpha1.HelmRelease{}
+	instanceResp = &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseSuccess))
@@ -255,88 +204,17 @@ func TestHelmRepoSuccess(t *testing.T) {
 	}, secret)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	owners := secret.GetOwnerReferences()
-	g.Expect((len(owners) == 1)).Should(gomega.BeTrue())
-	g.Expect(owners[0].Name).Should(gomega.Equal(instanceResp.Name))
-	g.Expect(owners[0].UID).Should(gomega.Equal(instanceResp.UID))
-
-	err = c.Delete(context.TODO(), instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-}
-
-func TestReleaseActions(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	c := mgr.GetClient()
-
-	rec := &ReconcileHelmRelease{
-		mgr,
-	}
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
 	//Check new ReleaseName
-	helmReleaseName := "example-helmrepo-succeed"
-	helmReleaseKey := types.NamespacedName{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}
-	instance := &appv1alpha1.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HelmRelease",
-			APIVersion: "app.ibm.com/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      helmReleaseName,
-			Namespace: helmReleaseNS,
-		},
-		Spec: appv1alpha1.HelmReleaseSpec{
-			Source: &appv1alpha1.Source{
-				SourceType: appv1alpha1.HelmRepoSourceType,
-				HelmRepo: &appv1alpha1.HelmRepo{
-					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
-				},
-			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
-		},
-	}
-	utils.AddFinalizer(instance)
-
-	err = c.Create(context.TODO(), instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	instanceResp := &appv1alpha1.HelmRelease{}
-	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
 	instanceResp.Spec.ReleaseName = "example-helmrepo-succeed-rename"
 	err = c.Update(context.TODO(), instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	req := reconcile.Request{}
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	instanceResp = &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+	t.Logf("Reason: %s", instanceResp.Status.Reason)
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
-
-	err = c.Delete(context.TODO(), instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	//Check duplicate
 	helmReleaseName = "example-helmrepo-succeed-duplicate"
@@ -351,66 +229,24 @@ func TestReleaseActions(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	time.Sleep(4 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	instanceResp = &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
 
-	c.Delete(context.TODO(), instanceResp)
-
-	_, err = rec.Reconcile(req)
-
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	_, err = rec.Reconcile(req)
-
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-}
-
-func TestHelmRepoFailure(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
-	// channel when it is finished.
-
-	t.Log("Create manager")
-
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	c := mgr.GetClient()
-
-	rec := &ReconcileHelmRelease{
-		mgr,
-	}
-
-	t.Log("Start test reconcile")
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
 	//
 	//helmRepo failure
 	//
 	t.Log("Github failure test")
 
-	helmReleaseName := "example-helmrepo-failure"
-	helmReleaseKey := types.NamespacedName{
+	helmReleaseName = "example-helmrepo-failure"
+	helmReleaseKey = types.NamespacedName{
 		Name:      helmReleaseName,
 		Namespace: helmReleaseNS,
 	}
-	instance := &appv1alpha1.HelmRelease{
+	instance = &appv1alpha1.HelmRelease{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HelmRelease",
 			APIVersion: "app.ibm.com/v1alpha1",
@@ -434,13 +270,9 @@ func TestHelmRepoFailure(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	req := reconcile.Request{}
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
 	time.Sleep(4 * time.Second)
 
-	instanceResp := &appv1alpha1.HelmRelease{}
+	instanceResp = &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -482,16 +314,13 @@ func TestHelmRepoFailure(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	instanceRespCD := &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceRespCD)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	g.Expect(instanceRespCD.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseSuccess))
 
@@ -499,7 +328,7 @@ func TestHelmRepoFailure(t *testing.T) {
 	err = c.Delete(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(8 * time.Second)
 
 	instanceRespDel := &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceRespDel)
@@ -545,10 +374,7 @@ func TestHelmRepoFailure(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	t.Log("Github succeed create-update -> CR get response")
 
@@ -573,9 +399,7 @@ func TestHelmRepoFailure(t *testing.T) {
 	err = c.Update(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	t.Log("Github succeed create-update -> CR get response")
 
@@ -609,6 +433,9 @@ func TestHelmRepoFailure(t *testing.T) {
 
 	time.Sleep(6 * time.Second)
 
+	_, err = rec.newHelmReleaseManager(instance)
+	assert.NoError(t, err)
+
 	// TestNewManagerShortReleaseName
 	helmReleaseName = "test-new-manager-short-release-name"
 	instance = &appv1alpha1.HelmRelease{
@@ -633,6 +460,9 @@ func TestHelmRepoFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	time.Sleep(6 * time.Second)
+
+	_, err = rec.newHelmReleaseManager(instance)
+	assert.NoError(t, err)
 
 	// TestNewManagerValues
 	helmReleaseName = "test-new-manager-values"
@@ -660,6 +490,9 @@ func TestHelmRepoFailure(t *testing.T) {
 
 	time.Sleep(6 * time.Second)
 
+	//Values well formed
+	_, err = rec.newHelmReleaseManager(instance)
+	assert.NoError(t, err)
 	//Values not a yaml
 	instance.Spec.Values = "l1:\nl2"
 	_, err = rec.newHelmReleaseManager(instance)

--- a/pkg/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,88 +32,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appv1alpha1 "github.com/IBM/multicloud-operators-subscription-release/pkg/apis/app/v1alpha1"
+	"github.com/IBM/multicloud-operators-subscription-release/pkg/utils"
 )
 
 var (
-	helmReleaseNS = "kube-system"
+	helmReleaseNS = "default"
 )
-
-func TestGithubFailed(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
-
-	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
-	// channel when it is finished.
-
-	mgr, err := manager.New(cfg, manager.Options{
-		MetricsBindAddress: "0",
-		LeaderElection:     false,
-	})
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	c := mgr.GetClient()
-
-	rec := &ReconcileHelmRelease{
-		mgr,
-	}
-
-	stopMgr, mgrStopped := StartTestManager(mgr, g)
-
-	defer func() {
-		close(stopMgr)
-		mgrStopped.Wait()
-	}()
-
-	//Github failed
-	helmReleaseName := "example-github-failed"
-	helmReleaseKey := types.NamespacedName{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}
-	instance := &appv1alpha1.HelmRelease{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "HelmRelease",
-			APIVersion: "app.ibm.com/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      helmReleaseName,
-			Namespace: helmReleaseNS,
-		},
-		Spec: appv1alpha1.HelmReleaseSpec{
-			Source: &appv1alpha1.Source{
-				SourceType: appv1alpha1.GitHubSourceType,
-				GitHub: &appv1alpha1.GitHub{
-					Urls:      []string{"https://github.com/IBM/multicloud-operators-subscription-release.git"},
-					ChartPath: "wrong path",
-				},
-			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
-		},
-	}
-
-	err = c.Create(context.TODO(), instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	req := reconcile.Request{}
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(1 * time.Second)
-
-	instanceResp := &appv1alpha1.HelmRelease{}
-	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
-
-	c.Delete(context.TODO(), instanceResp)
-
-	_, err = rec.Reconcile(req)
-
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-}
 
 func TestGithubSuccess(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -124,12 +49,10 @@ func TestGithubSuccess(t *testing.T) {
 		LeaderElection:     false,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
 
 	c := mgr.GetClient()
 
-	rec := &ReconcileHelmRelease{
-		mgr,
-	}
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 
 	defer func() {
@@ -170,13 +93,7 @@ func TestGithubSuccess(t *testing.T) {
 	err = c.Create(context.TODO(), instance)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	req := reconcile.Request{}
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	instanceResp := &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
@@ -184,15 +101,93 @@ func TestGithubSuccess(t *testing.T) {
 
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseSuccess))
 
-	c.Delete(context.TODO(), instanceResp)
-
-	_, err = rec.Reconcile(req)
-
+	secret := &corev1.Secret{}
+	err = c.Get(context.TODO(), types.NamespacedName{
+		Name:      helmReleaseName,
+		Namespace: helmReleaseNS,
+	}, secret)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	_, err = rec.Reconcile(req)
+	owners := secret.GetOwnerReferences()
+	g.Expect((len(owners) == 1)).Should(gomega.BeTrue())
+	g.Expect(owners[0].Name).Should(gomega.Equal(instanceResp.Name))
+	g.Expect(owners[0].UID).Should(gomega.Equal(instanceResp.UID))
 
+	deploy := &appv1.DeploymentList{}
+	c.List(context.TODO(), deploy)
+	g.Expect(len(deploy.Items) == 1).To(gomega.BeTrue())
+
+	err = c.Delete(context.TODO(), instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer time.Sleep(2 * time.Second)
+}
+
+func TestGithubFailed(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
+	// channel when it is finished.
+
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: "0",
+		LeaderElection:     false,
+	})
+	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	c := mgr.GetClient()
+
+	//Github failed
+	helmReleaseName := "example-github-failed"
+	helmReleaseKey := types.NamespacedName{
+		Name:      helmReleaseName,
+		Namespace: helmReleaseNS,
+	}
+	instance := &appv1alpha1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "app.ibm.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmReleaseName,
+			Namespace: helmReleaseNS,
+		},
+		Spec: appv1alpha1.HelmReleaseSpec{
+			Source: &appv1alpha1.Source{
+				SourceType: appv1alpha1.GitHubSourceType,
+				GitHub: &appv1alpha1.GitHub{
+					Urls:      []string{"https://github.com/IBM/multicloud-operators-subscription-release.git"},
+					ChartPath: "wrong path",
+				},
+			},
+			ReleaseName: helmReleaseName,
+			ChartName:   "subscription-release-test-1",
+		},
+	}
+
+	err = c.Create(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	time.Sleep(4 * time.Second)
+
+	instanceResp := &appv1alpha1.HelmRelease{}
+	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
+
+	err = c.Delete(context.TODO(), instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	defer time.Sleep(2 * time.Second)
 }
 
 func TestHelmRepoSuccess(t *testing.T) {
@@ -205,12 +200,10 @@ func TestHelmRepoSuccess(t *testing.T) {
 		LeaderElection:     false,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Expect(Add(mgr)).NotTo(gomega.HaveOccurred())
 
 	c := mgr.GetClient()
 
-	rec := &ReconcileHelmRelease{
-		mgr,
-	}
 	stopMgr, mgrStopped := StartTestManager(mgr, g)
 
 	defer func() {
@@ -245,14 +238,7 @@ func TestHelmRepoSuccess(t *testing.T) {
 			ChartName:   "subscription-release-test-1",
 		},
 	}
-
 	err = c.Create(context.TODO(), instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	req := reconcile.Request{}
-	req.NamespacedName = helmReleaseKey
-	_, err = rec.Reconcile(req)
-
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	time.Sleep(2 * time.Second)
@@ -269,13 +255,76 @@ func TestHelmRepoSuccess(t *testing.T) {
 	}, secret)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
+	owners := secret.GetOwnerReferences()
+	g.Expect((len(owners) == 1)).Should(gomega.BeTrue())
+	g.Expect(owners[0].Name).Should(gomega.Equal(instanceResp.Name))
+	g.Expect(owners[0].UID).Should(gomega.Equal(instanceResp.UID))
+
+	err = c.Delete(context.TODO(), instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+}
+
+func TestReleaseActions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	mgr, err := manager.New(cfg, manager.Options{
+		MetricsBindAddress: "0",
+		LeaderElection:     false,
+	})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	c := mgr.GetClient()
+
+	rec := &ReconcileHelmRelease{
+		mgr,
+	}
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
 	//Check new ReleaseName
+	helmReleaseName := "example-helmrepo-succeed"
+	helmReleaseKey := types.NamespacedName{
+		Name:      helmReleaseName,
+		Namespace: helmReleaseNS,
+	}
+	instance := &appv1alpha1.HelmRelease{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "HelmRelease",
+			APIVersion: "app.ibm.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helmReleaseName,
+			Namespace: helmReleaseNS,
+		},
+		Spec: appv1alpha1.HelmReleaseSpec{
+			Source: &appv1alpha1.Source{
+				SourceType: appv1alpha1.HelmRepoSourceType,
+				HelmRepo: &appv1alpha1.HelmRepo{
+					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
+				},
+			},
+			ReleaseName: helmReleaseName,
+			ChartName:   "subscription-release-test-1",
+		},
+	}
+	utils.AddFinalizer(instance)
+
+	err = c.Create(context.TODO(), instance)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
+	instanceResp := &appv1alpha1.HelmRelease{}
+	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+
 	instanceResp.Spec.ReleaseName = "example-helmrepo-succeed-rename"
 	err = c.Update(context.TODO(), instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	_, err = rec.Reconcile(req)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	req := reconcile.Request{}
+	req.NamespacedName = helmReleaseKey
 	_, err = rec.Reconcile(req)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -284,17 +333,9 @@ func TestHelmRepoSuccess(t *testing.T) {
 	instanceResp = &appv1alpha1.HelmRelease{}
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	t.Logf("Reason: %s", instanceResp.Status.Reason)
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
 
-	c.Delete(context.TODO(), instanceResp)
-
-	_, err = rec.Reconcile(req)
-
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	_, err = rec.Reconcile(req)
-
+	err = c.Delete(context.TODO(), instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	//Check duplicate
@@ -621,7 +662,7 @@ func TestHelmRepoFailure(t *testing.T) {
 
 	//Values not a yaml
 	instance.Spec.Values = "l1:\nl2"
-	_, _, err = rec.newHelmReleaseManager(instance)
+	_, err = rec.newHelmReleaseManager(instance)
 	assert.Error(t, err)
 
 	// TestNewManagerErrors
@@ -653,7 +694,7 @@ func TestHelmRepoFailure(t *testing.T) {
 	//Download Chart should fail
 	instance.Spec.Source.GitHub.Urls[0] = "wrongurl"
 	instance.Spec.Values = "l1:\nl2"
-	_, _, err = rec.newHelmReleaseManager(instance)
+	_, err = rec.newHelmReleaseManager(instance)
 	assert.Error(t, err)
 
 	// TestNewManagerForDeletion
@@ -691,7 +732,7 @@ func TestHelmRepoFailure(t *testing.T) {
 	time.Sleep(6 * time.Second)
 
 	instance.GetObjectMeta().SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
-	mgrhr, _, err := rec.newHelmReleaseManager(instance)
+	mgrhr, err := rec.newHelmReleaseManager(instance)
 	assert.NoError(t, err)
 
 	assert.Equal(t, mgrhr.ReleaseName(), helmReleaseName)


### PR DESCRIPTION
Signed-off-by: Kuan Feng <fengkuan@gmail.com>

- added team member
- use single controller-runtime/manager rather than 1 for each release
- use controllerutil.SetOwnerrefernce to ensure controller:true is set
- consolidate the Update action
- Change the test from recFn with channel to simply Add