### PR TITLE
Fix image reference by pointing to quay.io

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -62,7 +62,7 @@ spec:
       containers:
       - name: multicloud-operators-subscription-release
         # Replace this with the built image name
-        image: hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom/multicloud-operators-subscription-release-amd64:latest
+        image: quay.io/multicloudlab/multicloud-operators-subscription-release
         command:
         - multicloud-operators-subscription-release
         imagePullPolicy: Always


### PR DESCRIPTION
Image is set to multicloudlab/multicloud-operators-subscription-release

Signed-off-by: Richard Su <rwsu@redhat.com>