### PR TITLE
consolidate releasename and cr name into just using cr name

### DIFF
--- a/deploy/crds/app.ibm.com_helmreleases_crd.yaml
+++ b/deploy/crds/app.ibm.com_helmreleases_crd.yaml
@@ -71,11 +71,6 @@ spec:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
-            releaseName:
-              description: ReleaseName is the Name of the release given to Tiller.
-                Defaults to namespace-name. Must not be changed after initial object
-                creation.
-              type: string
             secretRef:
               description: Secret to use to access the helm-repo defined in the CatalogSource.
               properties:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -197,7 +197,7 @@ Once the HelmRelease is created or modified, the operator will deploy each chart
 To do so, the following steps are taken:
 
 1) Download the chart tgz in the `$CHARTS_DIR`.
-2) Unzip the tgz in `$CHARTS_DIR/<sr.Spec.ReleaseName>/<sr.namespace>/<chart_name>`
+2) Unzip the tgz in `$CHARTS_DIR/<sr.name>/<sr.namespace>/<chart_name>`
 3) Create a manager with the values provided in the HelmRelease
 4) Launch the deployment.
 

--- a/pkg/apis/app/v1alpha1/helmrelease_types.go
+++ b/pkg/apis/app/v1alpha1/helmrelease_types.go
@@ -37,10 +37,6 @@ const (
 	HelmReleaseSuccess HelmReleaseStatusEnum = "Success"
 )
 
-const (
-	ReleaseSecretAnnotationKey = "release-secret"
-)
-
 //SourceTypeEnum types of sources
 type SourceTypeEnum string
 
@@ -99,8 +95,6 @@ type HelmReleaseSpec struct {
 	Source *Source `json:"source,omitempty"`
 	// ChartName is the name of the chart within the repo
 	ChartName string `json:"chartName,omitempty"`
-	// ReleaseName is the Name of the release given to Tiller. Defaults to namespace-name. Must not be changed after initial object creation.
-	ReleaseName string `json:"releaseName,omitempty"`
 	// Version is the chart version
 	Version string `json:"version,omitempty"`
 	// Values is a string containing (unparsed) YAML values

--- a/pkg/apis/app/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/app/v1alpha1/zz_generated.openapi.go
@@ -139,13 +139,6 @@ func schema_pkg_apis_app_v1alpha1_HelmReleaseSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
-					"releaseName": {
-						SchemaProps: spec.SchemaProps{
-							Description: "ReleaseName is the Name of the release given to Tiller. Defaults to namespace-name. Must not be changed after initial object creation.",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Version is the chart version",

--- a/pkg/controller/helmrelease/helmrelease_controller.go
+++ b/pkg/controller/helmrelease/helmrelease_controller.go
@@ -19,7 +19,6 @@ package helmrelease
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
@@ -156,7 +155,7 @@ func (r *ReconcileHelmRelease) Reconcile(request reconcile.Request) (reconcile.R
 }
 
 func (r *ReconcileHelmRelease) manageHelmRelease(sr *appv1alpha1.HelmRelease) error {
-	klog.V(3).Info("chart: ", sr.Spec.ChartName, " release:", sr.Spec.ReleaseName, "annotations:", sr.GetAnnotations())
+	klog.V(3).Info("chart: ", sr.Spec.ChartName, " release:", sr.GetName(), "annotations:", sr.GetAnnotations())
 
 	klog.V(5).Info("Create Manager")
 
@@ -209,7 +208,7 @@ func (r *ReconcileHelmRelease) manageHelmRelease(sr *appv1alpha1.HelmRelease) er
 }
 
 func (r *ReconcileHelmRelease) prepareHelmRelease(sr *appv1alpha1.HelmRelease) bool {
-	klog.V(3).Info("chart: ", sr.Spec.ChartName, " release:", sr.Spec.ReleaseName, "annotations:", sr.GetAnnotations())
+	klog.V(3).Info("namespace: ", sr.Namespace, " name: ", sr.Name, " chart: ", sr.Spec.ChartName)
 
 	needUpdate := false
 
@@ -218,29 +217,6 @@ func (r *ReconcileHelmRelease) prepareHelmRelease(sr *appv1alpha1.HelmRelease) b
 		utils.AddFinalizer(sr)
 
 		needUpdate = true
-	}
-
-	annotations := sr.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
-	exsec := annotations[appv1alpha1.ReleaseSecretAnnotationKey]
-	relsec := sr.Namespace + "/" + sr.Spec.ReleaseName
-
-	if exsec == "" {
-		exsec = relsec
-		annotations[appv1alpha1.ReleaseSecretAnnotationKey] = relsec
-		sr.SetAnnotations(annotations)
-
-		needUpdate = true
-	}
-
-	if exsec != relsec {
-		err := fmt.Errorf("release name can not be changed: new %s, old %s", relsec, exsec)
-		_, _ = r.SetStatus(sr, err)
-
-		return true
 	}
 
 	if needUpdate {

--- a/pkg/controller/helmrelease/helmrelease_controller_test.go
+++ b/pkg/controller/helmrelease/helmrelease_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -96,8 +95,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -140,8 +138,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "wrong path",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -182,8 +179,7 @@ func TestReconcile(t *testing.T) {
 					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -196,45 +192,6 @@ func TestReconcile(t *testing.T) {
 	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseSuccess))
-
-	secret := &corev1.Secret{}
-	err = c.Get(context.TODO(), types.NamespacedName{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}, secret)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	//Check new ReleaseName
-	instanceResp.Spec.ReleaseName = "example-helmrepo-succeed-rename"
-	err = c.Update(context.TODO(), instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	time.Sleep(4 * time.Second)
-
-	instanceResp = &appv1alpha1.HelmRelease{}
-	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	t.Logf("Reason: %s", instanceResp.Status.Reason)
-	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
-
-	//Check duplicate
-	helmReleaseName = "example-helmrepo-succeed-duplicate"
-	helmReleaseKey = types.NamespacedName{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}
-	instance.ObjectMeta = metav1.ObjectMeta{
-		Name:      helmReleaseName,
-		Namespace: helmReleaseNS,
-	}
-	err = c.Create(context.TODO(), instance)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	time.Sleep(2 * time.Second)
-
-	instanceResp = &appv1alpha1.HelmRelease{}
-	err = c.Get(context.TODO(), helmReleaseKey, instanceResp)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-	g.Expect(instanceResp.Status.Status).To(gomega.Equal(appv1alpha1.HelmReleaseFailed))
 
 	//
 	//helmRepo failure
@@ -262,8 +219,7 @@ func TestReconcile(t *testing.T) {
 					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/wrongurl"},
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -305,8 +261,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -363,8 +318,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -423,8 +377,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: "subscription-release-test-1",
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -451,8 +404,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -479,9 +431,8 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
-			Values:      "l1:v1",
+			ChartName: "subscription-release-test-1",
+			Values:    "l1:v1",
 		},
 	}
 
@@ -514,8 +465,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 
@@ -554,8 +504,7 @@ func TestReconcile(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: helmReleaseName,
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 

--- a/pkg/helmreposubscriber/hrsubscriber.go
+++ b/pkg/helmreposubscriber/hrsubscriber.go
@@ -477,7 +477,12 @@ func (s *HelmRepoSubscriber) newHelmChartHelmReleaseForCR(chartVersion *repo.Cha
 		return nil, err
 	}
 
-	releaseName := chartVersion.Name + "-" + s.HelmChartSubscription.Name + "-" + s.HelmChartSubscription.Namespace
+	name := chartVersion.Name
+	subUID := string(s.HelmChartSubscription.UID)
+
+	if len(subUID) >= 5 {
+		name += "-" + subUID[:5]
+	}
 
 	for i := range chartVersion.URLs {
 		parsedURL, err := url.Parse(chartVersion.URLs[i])
@@ -494,7 +499,7 @@ func (s *HelmRepoSubscriber) newHelmChartHelmReleaseForCR(chartVersion *repo.Cha
 	//Compose release name
 	sr := &appv1alpha1.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        releaseName,
+			Name:        name,
 			Namespace:   s.HelmChartSubscription.Namespace,
 			Annotations: annotations,
 		},
@@ -503,7 +508,6 @@ func (s *HelmRepoSubscriber) newHelmChartHelmReleaseForCR(chartVersion *repo.Cha
 			ConfigMapRef: s.HelmChartSubscription.Spec.ConfigMapRef,
 			SecretRef:    s.HelmChartSubscription.Spec.SecretRef,
 			ChartName:    chartVersion.Name,
-			ReleaseName:  releaseName,
 			Version:      chartVersion.GetVersion(),
 			Values:       values,
 		},

--- a/pkg/helmreposubscriber/hrsubscriber_test.go
+++ b/pkg/helmreposubscriber/hrsubscriber_test.go
@@ -617,7 +617,7 @@ func TestNewHelmChartHelmReleaseForCR(t *testing.T) {
 
 	hr, err := subscriber.newHelmChartHelmReleaseForCR(indexFile.Entries["ibm-cfee-installer"][0])
 	assert.NoError(t, err)
-	assert.Equal(t, "ibm-cfee-installer-test-helmsubscriber-default", hr.Spec.ReleaseName)
+	assert.Contains(t, hr.Name, "ibm-cfee-installer")
 }
 
 func TestGetValues(t *testing.T) {

--- a/pkg/utils/helmrepoutils.go
+++ b/pkg/utils/helmrepoutils.go
@@ -106,7 +106,7 @@ func DownloadChart(configMap *corev1.ConfigMap,
 	secret *corev1.Secret,
 	chartsDir string,
 	s *appv1alpha1.HelmRelease) (chartDir string, err error) {
-	destRepo := filepath.Join(chartsDir, s.Spec.ReleaseName, s.Namespace, s.Spec.ChartName)
+	destRepo := filepath.Join(chartsDir, s.Name, s.Namespace, s.Spec.ChartName)
 	if _, err := os.Stat(destRepo); os.IsNotExist(err) {
 		err := os.MkdirAll(destRepo, 0755)
 		if err != nil {
@@ -699,7 +699,7 @@ func CreateFakeChart(chartsDir string, s *appv1alpha1.HelmRelease) (chartDir str
 
 	fileName := filepath.Join(dirName, "Chart.yaml")
 	chart := &chart.Metadata{
-		Name: s.Spec.ReleaseName,
+		Name: s.Name,
 	}
 
 	return dirName, chartutil.SaveChartfile(fileName, chart)

--- a/pkg/utils/helmrepoutils_test.go
+++ b/pkg/utils/helmrepoutils_test.go
@@ -222,8 +222,7 @@ func TestDownloadChartGitHub(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: "subscription-release-test-1",
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -251,8 +250,7 @@ func TestDownloadChartHelmRepo(t *testing.T) {
 					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
 				},
 			},
-			ChartName:   "subscription-release-test-1",
-			ReleaseName: "subscription-release-test-1-release",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -281,8 +279,7 @@ func TestDownloadChartHelmRepoContainsInvalidURL(t *testing.T) {
 						"https://badURL1"},
 				},
 			},
-			ChartName:   "subscription-release-test-1",
-			ReleaseName: "subscription-release-test-1-release",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -311,8 +308,7 @@ func TestDownloadChartHelmRepoContainsInvalidURL2(t *testing.T) {
 						"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
 				},
 			},
-			ChartName:   "subscription-release-test-1",
-			ReleaseName: "subscription-release-test-1-release",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -340,8 +336,7 @@ func TestDownloadChartHelmRepoAllInvalidURLs(t *testing.T) {
 					Urls: []string{"https://badURL1", "https://badURL2", "https://badURL3", "https://badURL4", "https://badURL5"},
 				},
 			},
-			ChartName:   "subscription-release-test-1",
-			ReleaseName: "subscription-release-test-1-release",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -367,8 +362,7 @@ func TestDownloadChartFromGitHub(t *testing.T) {
 					ChartPath: "test/github/subscription-release-test-1",
 				},
 			},
-			ReleaseName: "subscription-release-test-1",
-			ChartName:   "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -396,8 +390,7 @@ func TestDownloadChartFromHelmRepoHTTP(t *testing.T) {
 					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
 				},
 			},
-			ChartName:   "subscription-release-test-1",
-			ReleaseName: "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -425,8 +418,7 @@ func TestDownloadChartFromHelmRepoLocal(t *testing.T) {
 					Urls: []string{"file:../../test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
 				},
 			},
-			ChartName:   "subscription-release-test-1",
-			ReleaseName: "subscription-release-test-1",
+			ChartName: "subscription-release-test-1",
 		},
 	}
 	dir, err := ioutil.TempDir("/tmp", "charts")
@@ -549,8 +541,7 @@ func TestCreateFakeChart(t *testing.T) {
 					Urls: []string{"https://raw.github.com/IBM/multicloud-operators-subscription-release/master/test/helmrepo/subscription-release-test-1-0.1.0.tgz"},
 				},
 			},
-			ChartName:   "subscription-release-test-1-c",
-			ReleaseName: "subscription-release-test-1",
+			ChartName: "subscription-release-test-1-c",
 		},
 	}
 
@@ -560,5 +551,5 @@ func TestCreateFakeChart(t *testing.T) {
 	chart, err := chartutil.LoadDir(chartDir)
 	assert.NoError(t, err)
 
-	assert.Equal(t, "subscription-release-test-1", chart.GetMetadata().GetName())
+	assert.Equal(t, "subscription-release-test-1-cr", chart.GetMetadata().GetName())
 }


### PR DESCRIPTION
- Consolidate releasename and cr name into just using cr name
- Remove The spec.releasename, remove the creation of secret
- Use the actual helmrelease cr for helm manager

complimentary commit on the subscription side: https://github.com/mikeshng/multicloud-operators-subscription/commit/6c0b8029920c941641302a8620c6b960ca9ee029 (need `-release` to merge in first so I can change the go.mod to reference the dependency)

Signed-off-by: Mike Ng <mikeshngdev@gmail.com>